### PR TITLE
crates/vaas: add description and license

### DIFF
--- a/crates/vaas/Cargo.toml
+++ b/crates/vaas/Cargo.toml
@@ -2,6 +2,8 @@
 name = "wormhole-vaas"
 version = "0.1.0"
 edition = "2021"
+description = "Serialization/deserialization of Wormhole VAAs"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Needed description and license to publish crate.