### PR TITLE
remove rust version from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,8 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.14"
+version = "0.1.1"
 edition = "2021"
-rust-version = "1.65"
 authors = ["Wormhole Contributors"]
 license = "Apache-2.0"
 homepage = "https://github.com/wormhole-foundation/wormhole-sdk-rs"

--- a/crates/explorer-client/Cargo.toml
+++ b/crates/explorer-client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "wormhole-explorer-client"
+
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/raw-vaas/Cargo.toml
+++ b/crates/raw-vaas/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wormhole-raw-vaas"
 description = "Zero-copy deserialization of Wormhole VAAs"
+
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wormhole-sdk/Cargo.toml
+++ b/crates/wormhole-sdk/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wormhole-sdk"
 description = "SDK for interacting with Wormhole"
+
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Removed the rust version specification in Cargo.toml (mostly because Solana programs built with 1.14 cannot use these crates as dependencies since this Solana version uses 1.62).