### PR TITLE
vaas: remove anchor feature

### DIFF
--- a/crates/vaas/Cargo.toml
+++ b/crates/vaas/Cargo.toml
@@ -13,9 +13,6 @@ repository.workspace = true
 alloy-primitives.workspace = true
 hex-literal.workspace = true
 
-# anchor
-anchor-lang = { workspace = true, optional = true }
-
 serde = {workspace = true, optional = true, features = ["derive"]}
 serde_json = { workspace = true, optional = true }
 
@@ -23,5 +20,4 @@ serde_json = { workspace = true, optional = true }
 
 [features]
 default = []
-anchor = ["anchor-lang"]
 serde = ["dep:serde", "dep:serde_json", "alloy-primitives/serde"]

--- a/crates/vaas/src/utils.rs
+++ b/crates/vaas/src/utils.rs
@@ -1,18 +1,9 @@
 use alloy_primitives::FixedBytes;
 
-#[cfg(feature = "anchor")]
-fn anchor_keccak(buf: &[u8]) -> FixedBytes<32> {
-    anchor_lang::solana_program::keccak::hash(buf).0.into()
-}
-
 /// Simple keccak256 hash with configurable backend.
 #[inline]
 pub fn keccak256(buf: impl AsRef<[u8]>) -> FixedBytes<32> {
-    #[cfg(not(feature = "anchor"))]
-    return alloy_primitives::keccak256(buf);
-
-    #[cfg(feature = "anchor")]
-    anchor_keccak(buf.as_ref())
+    alloy_primitives::keccak256(buf)
 }
 
 /// Return the number of guardians to reach quorum.


### PR DESCRIPTION
This crate cannot be used for Solana programs, so we want to remove this feature.

wormhole-raw-vaas should be used instead.