### PR TITLE
raw-vaas: remove anchor feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 rust: ["stable", "beta", "nightly", "1.68"] # MSRV
-                flags: ["--no-default-features --features=off-chain", "--no-default-features --features=anchor", ""]
+                flags: ["--no-default-features --features=off-chain", "--no-default-features --features=ruint", ""]
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
-alloy-primitives = "0.2.0"
+alloy-primitives = "0.3.0"
 hex-literal = "0.4.1"
 anchor-lang = "0.28.0"
 

--- a/crates/raw-vaas/Cargo.toml
+++ b/crates/raw-vaas/Cargo.toml
@@ -13,20 +13,18 @@ repository.workspace = true
 
 [dependencies]
 
-anchor-lang = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, optional = true }
 
-ruint = { version = "=1.8", default-features = false, optional = true }
-ruint-macro = { version = "=1.0.2", optional = true }
+ruint = { version = "1.8", default-features = false, optional = true }
+ruint-macro = { version = "1.0.2", optional = true }
 
 [dev-dependencies]
 hex-literal.workspace = true
 
 [features]
-default =["off-chain", "ruint"]
+default = ["off-chain"]
 ruint = ["dep:ruint", "dep:ruint-macro"]
-off-chain = ["dep:alloy-primitives", "ruint"]
+off-chain = ["dep:alloy-primitives"]
 on-chain = []
-anchor = ["dep:anchor-lang", "ruint", "on-chain"]
 
 

--- a/crates/raw-vaas/src/lib.rs
+++ b/crates/raw-vaas/src/lib.rs
@@ -9,4 +9,6 @@ pub mod utils;
 pub mod support;
 
 #[cfg(all(feature = "off-chain", feature = "on-chain"))]
-compile_error!("Only one of `off-chain` or `on-chain` can be enabled. N.b. `off-chain` is on by default.");
+compile_error!(
+    "Only one of `off-chain` or `on-chain` can be enabled. N.b. `off-chain` is on by default."
+);

--- a/crates/raw-vaas/src/lib.rs
+++ b/crates/raw-vaas/src/lib.rs
@@ -9,4 +9,4 @@ pub mod utils;
 pub mod support;
 
 #[cfg(all(feature = "off-chain", feature = "on-chain"))]
-compile_error!("Only one of `off-chain` or `on-chain` can be enabled. N.b. `anchor` and other runtime features enable `on-chain`, and `off-chain` is on by default.");
+compile_error!("Only one of `off-chain` or `on-chain` can be enabled. N.b. `off-chain` is on by default.");

--- a/crates/raw-vaas/src/protocol.rs
+++ b/crates/raw-vaas/src/protocol.rs
@@ -173,16 +173,16 @@ impl<'a> Body<'a> {
         Ok(Self { span })
     }
 
-    // available when either `off-chain` or `anchor` feature is enabled
+    // available when `off-chain` feature is enabled
     #[inline]
-    #[cfg(any(feature = "off-chain", feature = "anchor"))]
+    #[cfg(feature = "off-chain")]
     pub fn digest(&self) -> [u8; 32] {
         crate::utils::keccak256(self)
     }
 
-    // available when either `off-chain` or `anchor` feature is enabled
+    // available when `off-chain` feature is enabled
     #[inline]
-    #[cfg(any(feature = "off-chain", feature = "anchor"))]
+    #[cfg(feature = "off-chain")]
     pub fn double_digest(&self) -> [u8; 32] {
         crate::utils::keccak256(self.digest())
     }

--- a/crates/raw-vaas/src/support/mod.rs
+++ b/crates/raw-vaas/src/support/mod.rs
@@ -2,10 +2,10 @@
 
 //! Provides support for EITHER ruint@1.8.0 OR alloy_primitives.
 
-#[cfg(feature = "on-chain")]
+#[cfg(feature = "ruint")]
 use ruint::Uint;
 
-#[cfg(all(feature = "off-chain", not(feature = "on-chain")))]
+#[cfg(not(feature = "ruint"))]
 use alloy_primitives::Uint;
 
 use crate::payloads::token_bridge::{Transfer, TransferWithMessage};

--- a/crates/raw-vaas/src/utils.rs
+++ b/crates/raw-vaas/src/utils.rs
@@ -1,17 +1,8 @@
-#[cfg(feature = "anchor")]
-fn anchor_keccak(buf: &[u8]) -> [u8; 32] {
-    anchor_lang::solana_program::keccak::hash(buf).0.into()
-}
-
 /// Simple keccak256 hash with configurable backend.
+#[cfg(all(feature = "off-chain", not(feature = "on-chain")))]
 #[inline]
 pub fn keccak256(buf: impl AsRef<[u8]>) -> [u8; 32] {
-    #[cfg(all(feature = "off-chain", not(feature = "on-chain")))]
-    return alloy_primitives::keccak256(buf).into();
-
-    #[cfg(feature = "anchor")]
-    #[cfg_attr(feature = "anchor", allow(unreachable_code))]
-    return anchor_keccak(buf.as_ref());
+    alloy_primitives::keccak256(buf).into()
 }
 
 /// Return the number of guardians to reach quorum.


### PR DESCRIPTION
For Solana programs, all we need to do is use features = ["ruint", "on-chain"] and set default features to false.

To generate message hash and digest, we can just pass the VAA body as_ref to keccak::hash.

This also upticks alloy in the workspace to 0.3.0.