### PR TITLE
one_or_many

### DIFF
--- a/crates/explorer-client/src/common.rs
+++ b/crates/explorer-client/src/common.rs
@@ -14,3 +14,68 @@ impl Pagination {
         }
     }
 }
+
+pub(crate) mod base64 {
+    use serde::{Deserialize, Serialize};
+    use serde::{Deserializer, Serializer};
+
+    use base64::Engine;
+
+    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+        let base64 = base64::engine::general_purpose::STANDARD.encode(v);
+        String::serialize(&base64, s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let base64 = String::deserialize(d)?;
+        base64::engine::general_purpose::STANDARD
+            .decode(base64.as_bytes())
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+pub(crate) mod one_or_many {
+    use std::marker::PhantomData;
+
+    use serde::{de::Visitor, Deserialize, Deserializer};
+
+    #[derive(Default)]
+    struct OneOrManyVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for OneOrManyVisitor<T>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("One, or several instances of a type")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut vec = Vec::new();
+            while let Some(elem) = seq.next_element()? {
+                vec.push(elem);
+            }
+            Ok(vec)
+        }
+
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            Ok(vec![T::deserialize(
+                serde::de::value::MapAccessDeserializer::new(map),
+            )?])
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>, T: Deserialize<'de>>(
+        d: D,
+    ) -> Result<Vec<T>, D::Error> {
+        d.deserialize_any(OneOrManyVisitor(PhantomData))
+    }
+}

--- a/crates/explorer-client/src/endpoints/vaa.rs
+++ b/crates/explorer-client/src/endpoints/vaa.rs
@@ -5,6 +5,7 @@ use crate::{ApiCall, Pagination, Result};
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct ExplorerVaaResponse {
+    #[serde(deserialize_with = "crate::common::one_or_many::deserialize")]
     /// The returned data.
     pub data: Vec<ExplorerVaa>,
     /// Pagination information (if any)
@@ -21,7 +22,7 @@ pub struct ExplorerVaa {
     pub emitter_chain: u16,
     pub emitter_addr: FixedBytes<32>,
     pub emitter_native_addr: String,
-    #[serde(with = "base64")]
+    #[serde(with = "crate::common::base64")]
     pub vaa: Vec<u8>,
     pub timestamp: String,
     pub updated_at: String,
@@ -75,21 +76,14 @@ impl ApiCall for VaaRequest {
     }
 }
 
-mod base64 {
-    use serde::{Deserialize, Serialize};
-    use serde::{Deserializer, Serializer};
+#[cfg(test)]
+mod test {
+    #[test]
+    fn deserialize_one() {
+        let json = r#"
+        {"data":{"sequence":276319,"id":"4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/276319","version":1,"emitterChain":4,"emitterAddr":"000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7","emitterNativeAddr":"0xb6f6d86a8f9879a9c87f643768d9efc38c1da6e7","guardianSetIndex":3,"vaa":"AQAAAAMNADNZINhn9wy5s5YAu/1kY0fyWT53DVEXg821bWnAF1PDHJMugUgOqwHJWWCCzab7Ko/k5Nd1gdHPISJJcQ9W7TAAAuINA/6ie9TyHDqfn7d31AWbG0/oXEUeFIuuL6UmnzohQNwU1yS/vYP5k0DyBX1ivAIOeQPcm2WK8PYE84ATOwwBA6ehL0tZ5qPefsPsF7BDjz+ArPY/EVveh262VQK03xZTCurJjlPFsU2HkD6lIacw+K23v93MZXya5oHfdd0HIUIBBABB6r2LV5Ke7yRDp8QD8TanEVEBd9V2AQvNWa8Z6kSaD03VeGUf0quTFaJFsZR3GYJQk7H3hcNOlHb2+FdsuWoABnnBa85DrkswM7q7cveqvKPB8nMBYTtVoTWNLB9GT1KzT67syadZIFdyMtYTPPi9j/aMoVXY1bJx9NUtE/AI15sBCeiqDTXpumVeBEF5zQwz26WzSnKZjPtIjJRMuuRlOVGJMF0T54TWtWlQW/qz9h8kwmd/36vzqFYDxp++ESBgsWYACwin+aSTzgMggaBLx/NqjRTJ/++PIgXOgctTTr+95WUTQVs2TEb/eZ13TXjQ5tM3sIcU93NA0IBAf3CmO2Yi3N8BDGC+7WMzGjnxsVY59gVAbA3EKnQRmVJO592mevX8L4+tOcU2XNHK2LqY71diEZ1t8wn48EaC1ByHndjYAKdhoYgBDWC0fWEFWkg7haEOSTcHrV/fxYufw2ozG9E/I2+ULXEgTO9iA8oWM8jloyvwIQ/QjoYyxz+kwwLZdVztGfqf5nIADsiMJw8Sl8y0FRQMOe5TQlQ1YfOuG464AmOEqWLQiJw2OHgBxCFqJZ50JWIj9L/Ywg5cQGqo5jsF0QlGHak2sKABEPWhC4N6dJiQujpFF0I1vapgsM4hGrSr8kwFYhgs43ONE+F50p6onhO7HxyHgg/Y7E37R49DEbDyE52ksuYYdoMBETseKzat0CZ5wkhzvJRipZyYpZBvvl0ZRYzK6WJKjCliRnB9ERlNUyix1L0mFba/1oJMtcsRckRtjWAM5/uIB9wAEhWWZjjLf600c3CLxqitntc1FXezCm+G9DFe4vRL4fs7DyLhbLjDrmA58eTUuAhdf4Jbzdd74XxnpRGwqMIUu/8BZRNbYpu9AAAABAAAAAAAAAAAAAAAALb22GqPmHmpyH9kN2jZ78OMHabnAAAAAAAEN18PAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7AnZRlwDhZ9DbAln7g7yjOJR85C/iw0uAMoXH6Zsmh0vYO6wKgAAaLohJsvKw49z0OqKjUh78eQDBaslYf2QHNwOP+7BfSFAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==","timestamp":"2023-09-26T22:29:54Z","updatedAt":"2023-09-26T22:30:51.888Z","indexedAt":"2023-09-26T22:30:51.888Z","txHash":"6e55b586b6cf34115bf9b8e6c4045a54e48b9feea919fd846ebbb3f7c122d5bb"},"pagination":{"next":""}}"#;
 
-    use base64::Engine;
-
-    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
-        let base64 = base64::engine::general_purpose::STANDARD.encode(v);
-        String::serialize(&base64, s)
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
-        let base64 = String::deserialize(d)?;
-        base64::engine::general_purpose::STANDARD
-            .decode(base64.as_bytes())
-            .map_err(serde::de::Error::custom)
+        let res: super::ExplorerVaaResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(res.data.len(), 1);
     }
 }

--- a/crates/explorer-client/tests/vaa.rs
+++ b/crates/explorer-client/tests/vaa.rs
@@ -17,7 +17,6 @@ async fn retrieve_vaas() {
     );
 
     let resp = client.send(&req).await;
-    dbg!(&resp);
 
     assert!(resp.is_ok());
 }
@@ -41,6 +40,29 @@ async fn retrieve_eth_token_bridge() {
 
     let vaas = resp.unwrap().data;
 
+    for vaa in vaas {
+        vaa.deser_vaa().unwrap();
+    }
+}
+
+async fn retrieve_single_vaa() {
+    let req = VaaRequest {
+        chain_id: Some(2),
+        emitter: Some(
+            hex!("0000000000000000000000003ee18B2214AFF97000D974cf647E7C347E8fa585").into(),
+        ),
+        sequence: Some(15),
+    };
+
+    let client = Client::new(
+        "https://api.wormscan.io/".parse().unwrap(),
+        Default::default(),
+    );
+
+    let resp = client.send(&req).await;
+
+    let vaas = resp.unwrap().data;
+    assert_eq!(vaas.len(), 1);
     for vaa in vaas {
         vaa.deser_vaa().unwrap();
     }


### PR DESCRIPTION
fixes VAA endpoint response to accept a single non-array response, as returned when the VAA is fully specified

this makes round-tripping lossy, as we will always re-serialize as a vec. nbd i think?