### PR TITLE
raw-vaas: add target chain check for global governance

### DIFF
--- a/crates/raw-vaas/src/payloads/core/gov.rs
+++ b/crates/raw-vaas/src/payloads/core/gov.rs
@@ -224,6 +224,10 @@ impl<'a> GuardianSetUpdate<'a> {
             return Err("GuardianSetUpdate span too short. Need at least 27 bytes (for at least 1 guardian)");
         }
 
+        if span[..2] != [0, 0] {
+            return Err("GuardianSetUpdate target chain must be 0")
+        }
+
         let expected_len = 7 + usize::from(span[6]) * 20;
         if span.len() != expected_len {
             return Err(

--- a/crates/raw-vaas/src/payloads/token_bridge/gov.rs
+++ b/crates/raw-vaas/src/payloads/token_bridge/gov.rs
@@ -152,6 +152,10 @@ impl<'a> RegisterChain<'a> {
             return Err("RegisterChain span too short. Need exactly 36 bytes");
         }
 
+        if span[..2] != [0, 0] {
+            return Err("RegisterChain target chain must be 0")
+        }
+
         Ok(RegisterChain { span: &span[..36] })
     }
 }


### PR DESCRIPTION
Before these bytes were not checked. Now they are checked to make sure that the target chain is zero (indicating that the governance action should apply to all chains).