### PR TITLE
raw-vaas: more clean up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Wormhole Contributors"]
 license = "Apache-2.0"

--- a/crates/raw-vaas/src/payloads/cctp/payloads.rs
+++ b/crates/raw-vaas/src/payloads/cctp/payloads.rs
@@ -102,7 +102,7 @@ impl<'a> WormholeCctpMessage<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Deposit<'a>(&'a [u8]);
 
-impl AsRef<[u8]> for Deposit<'_> {
+impl<'a> AsRef<[u8]> for Deposit<'a> {
     fn as_ref(&self) -> &[u8] {
         self.0
     }

--- a/crates/raw-vaas/src/protocol.rs
+++ b/crates/raw-vaas/src/protocol.rs
@@ -202,6 +202,12 @@ impl<'a> From<&'a [u8]> for Payload<'a> {
     }
 }
 
+impl<'a> From<Payload<'a>> for &'a [u8] {
+    fn from(value: Payload<'a>) -> Self {
+        value.0
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct GuardianSetSig<'a>(pub(crate) &'a [u8]);
 


### PR DESCRIPTION
Expose span in Payload<'a> via into. This is helpful for integrators writing their own zero-copy readers using the VAA Payload type.