### PR TITLE
universal/raw-vaas: pub protocol::Body

### DIFF
--- a/universal/raw-vaas/src/lib.rs
+++ b/universal/raw-vaas/src/lib.rs
@@ -1,5 +1,5 @@
 mod protocol;
-pub use protocol::{GuardianSetSig, Header, Payload, Vaa};
+pub use protocol::{Body, GuardianSetSig, Header, Payload, Vaa};
 
 mod payloads;
 pub use payloads::{cctp, core, token_bridge, GovernanceHeader, GovernanceMessage};


### PR DESCRIPTION
With the proposed Solana [verification shim design](https://github.com/wormholelabs-xyz/wormhole/tree/svm-shims/svm/wormhole-core-shims/programs/wormhole-verify-vaa-shim), an integrator will only need to parse the body, but it wasn't exported here 😿 